### PR TITLE
Make Teensy audio more robust

### DIFF
--- a/FirstContact_V2_2_AUDIO/FirstContact_V2_2_AUDIO.ino
+++ b/FirstContact_V2_2_AUDIO/FirstContact_V2_2_AUDIO.ino
@@ -1005,18 +1005,20 @@ bool getStableIsLinked(float l1, float r1) {
   static unsigned long bufferStartTime = 0;
   static bool buffering = false;
   bool candidateIsLinked = (l1 > thresh || r1 > thresh);
+
   if (candidateIsLinked != stableIsLinked) {
     if (!buffering) {
-      bufferStartTime = millis();
       buffering = true;
+      bufferStartTime = millis();
+      printTransition(buffering, stableIsLinked, candidateIsLinked);
     } else if (millis() - bufferStartTime >= TRANSITION_BUFFER_MS) {
       // Finished buffering. Finalize the transition to the new state.
-      stableIsLinked = candidateIsLinked;
       buffering = false;
+      printTransition(buffering, stableIsLinked, candidateIsLinked);
+      stableIsLinked = candidateIsLinked;
     } else {
       // Still buffering. Do not change stableIsLinked.
     }
-    printTransition(buffering, stableIsLinked, candidateIsLinked);
   } else {
     buffering = false;
   }

--- a/FirstContact_V2_2_AUDIO/FirstContact_V2_2_AUDIO.ino
+++ b/FirstContact_V2_2_AUDIO/FirstContact_V2_2_AUDIO.ino
@@ -1010,14 +1010,14 @@ bool audioSenseProcessSignal() {
   if (!isInitialized | isLinked != wasLinked) {
       unsigned long now = millis();
       unsigned long delta = now - lastTransitionTime;
-      Serial.print("Transition from ");
+      Serial.print("Transition: ");
       if (isInitialized) {
-        Serial.print(wasLinked ? "linked" : "unlinked");
+        Serial.print(wasLinked ? "Linked" : "Unlinked");
       } else {
-        Serial.print("uninitialized");
+        Serial.print("Uninitialized");
       }
       Serial.print(" to ");
-      Serial.print(isLinked ? "linked" : "unlinked");
+      Serial.print(isLinked ? "Linked" : "Unlinked");
       Serial.print(" after ");
       Serial.print(delta);
       Serial.println("ms.");
@@ -1122,14 +1122,11 @@ void playMusic(bool isInitialized, bool wasLinked, bool isLinked) {
 
   // State transition: Connected -> Disconnected.
   if (wasLinked && !isLinked) {
-    Serial.println("Transition: Connected -> Disconnected");
     pauseMusic();
   }
 
   // State transition: Disconnected -> Connected.
   else if (!wasLinked && isLinked) {
-    Serial.println("Transition: Disconnected -> Connected");
-
     if (musicState == MUSIC_STATE_PAUSED) {
       // If we were paused (previous disconnect), resume playback
       Serial.println("Resuming paused music");

--- a/FirstContact_V2_2_AUDIO/FirstContact_V2_2_AUDIO.ino
+++ b/FirstContact_V2_2_AUDIO/FirstContact_V2_2_AUDIO.ino
@@ -1006,7 +1006,13 @@ bool getStableIsLinked(float l1, float r1) {
   static bool buffering = false;
   bool candidateIsLinked = (l1 > thresh || r1 > thresh);
 
-  if (candidateIsLinked != stableIsLinked) {
+  if (!stableIsLinked && candidateIsLinked ) {
+    // Immediate transition to Linked for quick contact latency.
+    printTransition(buffering, stableIsLinked, candidateIsLinked);
+    stableIsLinked = true;
+    buffering = false;
+  } else if (stableIsLinked && !candidateIsLinked) {
+    // Buffer transition to Unlinked to mitigate flakiness.
     if (!buffering) {
       buffering = true;
       bufferStartTime = millis();
@@ -1020,6 +1026,7 @@ bool getStableIsLinked(float l1, float r1) {
       // Still buffering. Do not change stableIsLinked.
     }
   } else {
+    // If stable and candidate are the same, do nothing and stop buffering.
     buffering = false;
   }
   return stableIsLinked;


### PR DESCRIPTION
Iterates on the new audio setup and adds some buffering of state transitions to disconnect to reduce the frequency of spurious hiccups. Adds some polish.

This looks to have broken the display state, but I don't have time to investigate now. Will fix later when I make a pass at including music in the display output.