### PR TITLE
Add flexible audio channel mapping for spare DAC8x board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,4 +167,20 @@ lint-install: ## Install ruff linter
 	@echo "Installing ruff..."
 	@pip3 install ruff
 
-.PHONY: sync audio-list audio-status audio-deps tone-test tone-detect-test freq-sweep audio-test audio-demo 8ch-test 8ch-generate-tones 8ch-generate-sweep 8ch-generate-mixed 8ch-list tx-test tx-test-sim tone-detect-tx tone-detect-tx-sim stop kill-all help typecheck typecheck-install lint lint-install print-devices controller controller-test
+## Channel Mapping Tests
+channel-test: ## Test audio channel mapping (default mode)
+	@echo "Testing audio channel mapping..."
+	@cd raspberry_pi && ./audio/test_channel_mapping.py
+
+channel-test-spare: ## Test spare DAC8x channel mapping (channels 0,1,4,5)
+	@echo "Testing spare DAC8x mode (Eros/Elektra share channel 0)..."
+	@cd raspberry_pi && ./audio/test_channel_mapping.py --mode SPARE_DAC8X
+
+channel-test-single: ## Test single speaker mode (all on channel 0)
+	@echo "Testing single speaker mode..."
+	@cd raspberry_pi && ./audio/test_channel_mapping.py --mode SINGLE_SPEAKER
+
+channel-modes: ## List available channel mapping modes
+	@cd raspberry_pi && ./audio/test_channel_mapping.py --list
+
+.PHONY: sync audio-list audio-status audio-deps tone-test tone-detect-test freq-sweep audio-test audio-demo 8ch-test 8ch-generate-tones 8ch-generate-sweep 8ch-generate-mixed 8ch-list tx-test tx-test-sim tone-detect-tx tone-detect-tx-sim stop kill-all help typecheck typecheck-install lint lint-install print-devices controller controller-test channel-test channel-test-spare channel-test-single channel-modes

--- a/raspberry_pi/audio/test_channel_mapping.py
+++ b/raspberry_pi/audio/test_channel_mapping.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = [
+#   "numpy", "sounddevice", "ultraimport"
+# ]
+# ///
+"""Test utility for verifying audio channel mapping configurations.
+
+This script allows testing different channel mapping modes to ensure
+audio is routed correctly to physical outputs. It plays test tones
+on each statue channel and reports which physical output is active.
+
+Usage:
+    ./test_channel_mapping.py                  # Use default/env mode
+    ./test_channel_mapping.py --mode SPARE_DAC8X  # Test specific mode
+    ./test_channel_mapping.py --list          # List available modes
+"""
+
+import argparse
+import os
+import sys
+import time
+from typing import Optional
+
+import numpy as np
+import sounddevice as sd
+import ultraimport as ui
+
+# Import configuration modules
+Statue = ui.ultraimport("__dir__/../config/constants.py", "Statue")
+(
+    get_channel_mapping,
+    print_configuration,
+    CHANNEL_MAPPINGS,
+    get_mixing_gain,
+) = ui.ultraimport(
+    "__dir__/../config/audio_config.py",
+    ["get_channel_mapping", "print_configuration", "CHANNEL_MAPPINGS", "get_mixing_gain"],
+)
+configure_devices = ui.ultraimport("__dir__/../audio/devices.py", "configure_devices")
+
+
+def generate_test_tone(frequency: float, duration: float, sample_rate: int) -> np.ndarray:
+    """Generate a sine wave test tone.
+    
+    Args:
+        frequency: Tone frequency in Hz
+        duration: Duration in seconds
+        sample_rate: Sample rate in Hz
+    
+    Returns:
+        Numpy array containing the tone
+    """
+    t = np.linspace(0, duration, int(sample_rate * duration), False)
+    tone = np.sin(2 * np.pi * frequency * t)
+    # Apply fade in/out to avoid clicks
+    fade_samples = int(0.01 * sample_rate)  # 10ms fade
+    tone[:fade_samples] *= np.linspace(0, 1, fade_samples)
+    tone[-fade_samples:] *= np.linspace(1, 0, fade_samples)
+    return tone * 0.5  # Reduce volume
+
+
+def test_channel_mapping(mode: Optional[str] = None, duration: float = 2.0):
+    """Test audio channel mapping with test tones.
+    
+    Args:
+        mode: Channel mapping mode to test
+        duration: Duration of each test tone in seconds
+    """
+    print("\n" + "=" * 60)
+    print("Audio Channel Mapping Test")
+    print("=" * 60)
+    
+    # Print configuration
+    print_configuration(mode)
+    
+    # Configure devices
+    print("\nConfiguring audio devices...")
+    devices = configure_devices(channel_mode=mode, debug=False)
+    
+    if not devices:
+        print("ERROR: No audio devices found!")
+        return 1
+    
+    # Get device info
+    device_index = devices[0]["device_index"]
+    sample_rate = devices[0]["sample_rate"]
+    device_type = devices[0]["device_type"]
+    
+    print(f"\nUsing device {device_index} at {sample_rate} Hz")
+    print(f"Device type: {device_type}")
+    
+    # Get channel mapping
+    channel_mapping = get_channel_mapping(mode)
+    mixing_gain = get_mixing_gain(mode)
+    
+    # Test tones for each statue
+    tone_frequencies = {
+        Statue.EROS: 440,      # A4
+        Statue.ELEKTRA: 523,   # C5
+        Statue.SOPHIA: 659,    # E5
+        Statue.ULTIMO: 784,    # G5
+        Statue.ARIEL: 880,     # A5
+    }
+    
+    print("\n" + "-" * 60)
+    print("Playing test tones for each statue...")
+    print("Listen for which physical output is active")
+    print("-" * 60)
+    
+    for statue in [Statue.EROS, Statue.ELEKTRA, Statue.SOPHIA, Statue.ULTIMO, Statue.ARIEL]:
+        output_channel = channel_mapping[statue]
+        frequency = tone_frequencies[statue]
+        
+        print(f"\n{statue.value.upper()}: Channel {output_channel} - {frequency} Hz tone")
+        
+        # Check if this channel is shared
+        shared_with = [
+            s.value.upper() for s, ch in channel_mapping.items()
+            if ch == output_channel and s != statue
+        ]
+        if shared_with:
+            print(f"  (Shared with: {', '.join(shared_with)})")
+        
+        # Generate test tone
+        tone = generate_test_tone(frequency, duration, sample_rate)
+        
+        if device_type == "multi_channel":
+            # Multi-channel output (HiFiBerry)
+            max_channel = max(channel_mapping.values())
+            num_channels = max(8, max_channel + 1)
+            
+            # Create multi-channel array
+            audio = np.zeros((len(tone), num_channels))
+            audio[:, output_channel] = tone
+            
+            # Apply mixing gain if needed
+            if shared_with:
+                audio[:, output_channel] *= mixing_gain
+                print(f"  Applied mixing gain: {mixing_gain}")
+        else:
+            # Stereo output (USB devices)
+            audio = np.zeros((len(tone), 2))
+            audio[:, 0] = tone  # Left channel only
+        
+        # Play the tone
+        print("  Playing...", end="", flush=True)
+        sd.play(audio, sample_rate, device=device_index)
+        sd.wait()
+        print(" done")
+        
+        # Short pause between tones
+        time.sleep(0.5)
+    
+    print("\n" + "=" * 60)
+    print("Test complete!")
+    print("=" * 60)
+    
+    # Test mixed channels if applicable
+    mixed_channels = {}
+    for statue, channel in channel_mapping.items():
+        if channel not in mixed_channels:
+            mixed_channels[channel] = []
+        mixed_channels[channel].append(statue)
+    
+    mixed_channels = {ch: statues for ch, statues in mixed_channels.items() if len(statues) > 1}
+    
+    if mixed_channels:
+        print("\nTesting mixed channels...")
+        print("-" * 60)
+        
+        for channel, statues in mixed_channels.items():
+            print(f"\nChannel {channel}: Playing all statues simultaneously")
+            print(f"  Statues: {', '.join(s.value.upper() for s in statues)}")
+            
+            # Generate mixed tone
+            mixed_tone = np.zeros(int(sample_rate * duration))
+            for statue in statues:
+                frequency = tone_frequencies[statue]
+                tone = generate_test_tone(frequency, duration, sample_rate)
+                mixed_tone += tone * mixing_gain
+            
+            if device_type == "multi_channel":
+                audio = np.zeros((len(mixed_tone), num_channels))
+                audio[:, channel] = mixed_tone
+            else:
+                audio = np.zeros((len(mixed_tone), 2))
+                audio[:, 0] = mixed_tone
+            
+            print("  Playing mixed audio...", end="", flush=True)
+            sd.play(audio, sample_rate, device=device_index)
+            sd.wait()
+            print(" done")
+    
+    return 0
+
+
+def list_modes():
+    """List all available channel mapping modes."""
+    print("\nAvailable channel mapping modes:")
+    print("-" * 40)
+    for mode_name in CHANNEL_MAPPINGS.keys():
+        print(f"  {mode_name}")
+        if mode_name == "ORIGINAL":
+            print("    Standard 5-channel setup (default)")
+        elif mode_name == "SPARE_DAC8X":
+            print("    For spare board with channels 0,1,4,5")
+        elif mode_name == "SINGLE_SPEAKER":
+            print("    All statues on channel 0")
+    print("\nSet mode with: AUDIO_CHANNEL_MODE=<mode> ./controller.py")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test audio channel mapping configurations"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=list(CHANNEL_MAPPINGS.keys()),
+        help="Channel mapping mode to test",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=2.0,
+        help="Duration of each test tone in seconds (default: 2.0)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available channel mapping modes",
+    )
+    
+    args = parser.parse_args()
+    
+    if args.list:
+        list_modes()
+        return 0
+    
+    # Use mode from args or environment
+    mode = args.mode
+    if mode is None and "AUDIO_CHANNEL_MODE" in os.environ:
+        mode = os.environ["AUDIO_CHANNEL_MODE"]
+        print(f"Using mode from environment: {mode}")
+    
+    return test_channel_mapping(mode, args.duration)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/raspberry_pi/config/audio_config.py
+++ b/raspberry_pi/config/audio_config.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Audio channel configuration for Missing Link installation.
+
+This module provides flexible channel mapping configurations to support
+different hardware setups, including boards with fewer working channels.
+
+Configuration modes:
+- ORIGINAL: Standard 5-channel setup (channels 0-4)
+- SPARE_DAC8X: For spare board with channels 0,1,4,5 working
+- SINGLE_SPEAKER: All statues on one channel for testing
+"""
+
+import os
+from typing import Dict
+import ultraimport as ui
+
+Statue = ui.ultraimport("__dir__/constants.py", "Statue")
+
+
+# Channel mapping presets
+CHANNEL_MAPPINGS = {
+    "ORIGINAL": {
+        Statue.EROS: 0,
+        Statue.ELEKTRA: 1,
+        Statue.SOPHIA: 2,
+        Statue.ULTIMO: 3,
+        Statue.ARIEL: 4,
+    },
+    "SPARE_DAC8X": {
+        # For spare DAC8x with only channels 0,1,4,5 working
+        Statue.EROS: 0,      # Share channel 0
+        Statue.ELEKTRA: 0,   # Share channel 0
+        Statue.SOPHIA: 1,    # Channel 1
+        Statue.ULTIMO: 4,    # Channel 4
+        Statue.ARIEL: 5,     # Channel 5
+    },
+    "SINGLE_SPEAKER": {
+        # All statues on channel 0 for testing
+        Statue.EROS: 0,
+        Statue.ELEKTRA: 0,
+        Statue.SOPHIA: 0,
+        Statue.ULTIMO: 0,
+        Statue.ARIEL: 0,
+    }
+}
+
+
+def get_channel_mapping(mode: str = None) -> Dict[Statue, int]:
+    """Get the audio channel mapping configuration.
+    
+    Args:
+        mode: Optional mode override. If not provided, reads from
+              AUDIO_CHANNEL_MODE environment variable, defaults to "ORIGINAL"
+    
+    Returns:
+        Dictionary mapping Statue enum to physical output channel number
+    
+    Raises:
+        ValueError: If mode is not recognized
+    """
+    if mode is None:
+        mode = os.environ.get("AUDIO_CHANNEL_MODE", "ORIGINAL")
+    
+    mode = mode.upper()
+    if mode not in CHANNEL_MAPPINGS:
+        raise ValueError(
+            f"Unknown channel mode: {mode}. "
+            f"Valid modes: {', '.join(CHANNEL_MAPPINGS.keys())}"
+        )
+    
+    return CHANNEL_MAPPINGS[mode]
+
+
+def get_channels_for_output(output_channel: int, mode: str = None) -> list[Statue]:
+    """Get all statues mapped to a specific output channel.
+    
+    Args:
+        output_channel: Physical output channel number
+        mode: Optional mode override
+    
+    Returns:
+        List of Statue enums mapped to this output channel
+    """
+    mapping = get_channel_mapping(mode)
+    return [
+        statue for statue, channel in mapping.items()
+        if channel == output_channel
+    ]
+
+
+def requires_mixing(mode: str = None) -> bool:
+    """Check if the current mode requires audio mixing.
+    
+    Args:
+        mode: Optional mode override
+    
+    Returns:
+        True if any output channel has multiple inputs
+    """
+    mapping = get_channel_mapping(mode)
+    channel_counts = {}
+    for channel in mapping.values():
+        channel_counts[channel] = channel_counts.get(channel, 0) + 1
+    return any(count > 1 for count in channel_counts.values())
+
+
+def get_mixing_gain(mode: str = None) -> float:
+    """Get the gain adjustment for mixing multiple channels.
+    
+    Args:
+        mode: Optional mode override
+        
+    Returns:
+        Gain value to apply when mixing (0.0 to 1.0)
+    """
+    if not requires_mixing(mode):
+        return 1.0
+    
+    # Use 0.7 gain per channel to prevent clipping when mixing
+    return 0.7
+
+
+def print_configuration(mode: str = None):
+    """Print the current channel configuration for debugging."""
+    mapping = get_channel_mapping(mode)
+    mode_name = mode or os.environ.get("AUDIO_CHANNEL_MODE", "ORIGINAL")
+    
+    print(f"\nAudio Channel Configuration: {mode_name}")
+    print("-" * 40)
+    
+    # Group by output channel
+    outputs = {}
+    for statue, channel in mapping.items():
+        if channel not in outputs:
+            outputs[channel] = []
+        outputs[channel].append(statue.value.upper())
+    
+    for channel in sorted(outputs.keys()):
+        statues = outputs[channel]
+        if len(statues) > 1:
+            print(f"Channel {channel}: {', '.join(statues)} (SHARED)")
+        else:
+            print(f"Channel {channel}: {statues[0]}")
+    
+    if requires_mixing(mode):
+        print(f"\nMixing enabled with gain: {get_mixing_gain(mode)}")

--- a/raspberry_pi/contact/adg2188.py
+++ b/raspberry_pi/contact/adg2188.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["smbus2"]
+# ///
+
+"""ADG2188 8x8 Analog Switch Matrix Control
+
+This module provides low-level control of the ADG2188 analog crosspoint switch
+via I2C interface. The ADG2188 is used to route audio signals between statues
+while preventing signal loading issues.
+
+The switch matrix uses row-byte + LDSW programming:
+- Y inputs (rows): Connect to statue TX outputs
+- X outputs (columns): Connect to routing destinations
+- Row registers at 0x74-0x7B control Y0-Y7
+- Each bit in a row register connects to corresponding X output
+- LDSW register at 0x72 latches the configuration
+"""
+
+import smbus2
+from typing import Optional
+
+
+class ADG2188:
+    """Control ADG2188 8x8 analog switch matrix via I2C."""
+    
+    # Register addresses from datasheet
+    ROW_BASE = 0x74  # Y0 register (0x74-0x7B for Y0-Y7)
+    LDSW = 0x72      # Load switch register to latch configuration
+    
+    def __init__(self, bus: int = 1, address: int = 0x70):
+        """Initialize ADG2188 controller.
+        
+        Args:
+            bus: I2C bus number (1 for Pi I2C-1)
+            address: I2C address (0x70 default with JP1=000)
+        """
+        self.bus = smbus2.SMBus(bus)
+        self.address = address
+        self.rows = [0] * 8  # Shadow registers for Y0-Y7
+        self.clear_all()
+        
+    def connect(self, y_in: int, x_out: int) -> bool:
+        """Connect Y[y_in] input to X[x_out] output.
+        
+        Args:
+            y_in: Y input pin (0-7)
+            x_out: X output pin (0-7)
+            
+        Returns:
+            True if successful, False if invalid pins
+        """
+        if 0 <= y_in < 8 and 0 <= x_out < 8:
+            self.rows[y_in] |= (1 << x_out)
+            self._update()
+            return True
+        return False
+    
+    def disconnect(self, y_in: int, x_out: int) -> bool:
+        """Disconnect Y[y_in] from X[x_out].
+        
+        Args:
+            y_in: Y input pin (0-7)
+            x_out: X output pin (0-7)
+            
+        Returns:
+            True if successful, False if invalid pins
+        """
+        if 0 <= y_in < 8 and 0 <= x_out < 8:
+            self.rows[y_in] &= ~(1 << x_out)
+            self._update()
+            return True
+        return False
+    
+    def set_row(self, y_in: int, connections: int) -> bool:
+        """Set all connections for a Y row at once.
+        
+        Args:
+            y_in: Y input pin (0-7)
+            connections: 8-bit mask of X connections
+            
+        Returns:
+            True if successful, False if invalid pin
+        """
+        if 0 <= y_in < 8:
+            self.rows[y_in] = connections & 0xFF
+            self._update()
+            return True
+        return False
+    
+    def get_row(self, y_in: int) -> Optional[int]:
+        """Get current connections for a Y row.
+        
+        Args:
+            y_in: Y input pin (0-7)
+            
+        Returns:
+            8-bit mask of X connections, or None if invalid
+        """
+        if 0 <= y_in < 8:
+            return self.rows[y_in]
+        return None
+    
+    def clear_all(self):
+        """Open all switches."""
+        self.rows = [0] * 8
+        self._update()
+    
+    def _update(self):
+        """Write shadow registers to device and latch configuration."""
+        try:
+            # Write all row registers
+            for y, data in enumerate(self.rows):
+                self.bus.write_byte_data(
+                    self.address, 
+                    self.ROW_BASE + y, 
+                    data
+                )
+            # Latch the new configuration
+            self.bus.write_byte_data(self.address, self.LDSW, 0x01)
+        except Exception as e:
+            print(f"ADG2188 I2C error: {e}")
+            raise
+    
+    def get_connections(self) -> list[list[bool]]:
+        """Return current connection matrix.
+        
+        Returns:
+            8x8 matrix where [y][x] is True if connected
+        """
+        matrix = []
+        for y in range(8):
+            row = []
+            for x in range(8):
+                connected = bool(self.rows[y] & (1 << x))
+                row.append(connected)
+            matrix.append(row)
+        return matrix
+    
+    def print_matrix(self):
+        """Print connection matrix for debugging."""
+        print("ADG2188 Connection Matrix:")
+        print("     X0 X1 X2 X3 X4 X5 X6 X7")
+        print("   " + "-" * 28)
+        
+        matrix = self.get_connections()
+        for y, row in enumerate(matrix):
+            row_str = f"Y{y} |"
+            for x, connected in enumerate(row):
+                row_str += " ■ " if connected else " · "
+            print(row_str)
+    
+    def verify_communication(self) -> bool:
+        """Verify I2C communication with device.
+        
+        Returns:
+            True if device responds correctly
+        """
+        try:
+            # Try to read back a row register
+            data = self.bus.read_byte_data(self.address, self.ROW_BASE)
+            return True
+        except Exception:
+            return False
+
+
+def main():
+    """Test ADG2188 basic functionality."""
+    print("ADG2188 Basic Test")
+    print("-" * 40)
+    
+    try:
+        switch = ADG2188()
+        
+        if switch.verify_communication():
+            print("✓ I2C communication verified")
+        else:
+            print("✗ I2C communication failed")
+            return
+        
+        # Test connections
+        print("\nTest 1: Connect Y0 to X0")
+        switch.connect(0, 0)
+        switch.print_matrix()
+        
+        print("\nTest 2: Connect Y1 to multiple outputs")
+        switch.connect(1, 1)
+        switch.connect(1, 2)
+        switch.connect(1, 3)
+        switch.print_matrix()
+        
+        print("\nTest 3: Clear all")
+        switch.clear_all()
+        switch.print_matrix()
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        print("\nMake sure:")
+        print("- I2C is enabled on the Pi")
+        print("- ADG2188 is powered and connected")
+        print("- I2C address is correct (default 0x70)")
+
+
+if __name__ == "__main__":
+    main()

--- a/raspberry_pi/contact/adg2188_test.py
+++ b/raspberry_pi/contact/adg2188_test.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["smbus2", "sounddevice"]
+# ///
+
+"""Interactive ADG2188 TX switching test.
+
+This script provides an interactive terminal UI for testing TX switching
+functionality. It allows real-time control of statue TX connections to
+verify the ADG2188 switch matrix is working correctly.
+
+Controls:
+- W/S or ↑/↓: Navigate between statues
+- Space: Toggle TX connection for selected statue
+- E: Enable exclusive mode (only one TX at a time)
+- A: Disable all TX connections
+- M: Show connection matrix
+- Q: Quit
+"""
+
+import sys
+import termios
+import tty
+import time
+import select
+from typing import Optional
+
+from audio.devices import Statue
+
+try:
+    from tx_control import TXController
+except ImportError:
+    # If running standalone, try parent directory
+    sys.path.append('..')
+    from contact.tx_control import TXController
+
+
+class InteractiveTXTest:
+    """Interactive test UI for TX switching."""
+
+    def __init__(self, simulate: bool = False):
+        """Initialize test interface.
+
+        Args:
+            simulate: Run in simulation mode without hardware
+        """
+        self.controller = TXController(simulate=simulate)
+        self.running = True
+        self.selected_statue = Statue.EROS
+        self.show_matrix = False
+        self.old_settings = None
+
+    def setup_terminal(self):
+        """Set terminal to raw mode for immediate key capture."""
+        self.old_settings = termios.tcgetattr(sys.stdin)
+        tty.setraw(sys.stdin.fileno())
+
+    def restore_terminal(self):
+        """Restore terminal to normal mode."""
+        if self.old_settings:
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.old_settings)
+
+    def clear_screen(self):
+        """Clear terminal screen."""
+        print("\033[2J\033[H", end='', flush=True)
+
+    def draw_ui(self):
+        """Draw the interactive UI."""
+        self.clear_screen()
+
+        # Header
+        print("=== ADG2188 TX Switching Test ===\r\n\r", flush=True)
+
+        # Mode indicators
+        mode_str = "[HARDWARE MODE]" if self.controller.hardware_available else "[SIMULATION MODE]"
+        excl_str = "[EXCLUSIVE]" if self.controller.exclusive_mode else "[MULTI-TX]"
+        print(f"{mode_str} {excl_str}\r\n\r", flush=True)
+
+        # TX Status
+        print("TX Connection Status:\r", flush=True)
+        print("-" * 30 + "\r", flush=True)
+
+        for statue in Statue:
+            enabled = self.controller.is_tx_enabled(statue)
+            selected = "→" if statue == self.selected_statue else " "
+            status = "■ ON " if enabled else "□ OFF"
+
+            # Highlight selected row
+            if statue == self.selected_statue:
+                print(f"\033[7m{selected} {statue.value:8s} TX: [{status}]\033[0m\r", flush=True)
+            else:
+                print(f"{selected} {statue.value:8s} TX: [{status}]\r", flush=True)
+
+        # Show matrix if enabled
+        if self.show_matrix and self.controller.hardware_available:
+            print("\r\nConnection Matrix:\r", flush=True)
+            print("     X0 X1 X2 X3 X4 X5 X6 X7\r", flush=True)
+            print("   " + "-" * 28 + "\r", flush=True)
+
+            try:
+                matrix = self.controller.switch.get_connections()
+                for y, row in enumerate(matrix[:5]):  # Only show Y0-Y4 (statue rows)
+                    statue_name = list(self.controller.STATUE_TX_MAP.keys())[y].value[:3].upper()
+                    row_str = f"{statue_name} |"
+                    for x, connected in enumerate(row):
+                        if x == 0:  # Highlight bus column
+                            row_str += " ■ " if connected else " · "
+                        else:
+                            row_str += " · "  # Other columns not used
+                    print(row_str + "\r", flush=True)
+            except Exception:
+                print("[Matrix unavailable]\r", flush=True)
+
+        # Controls
+        print("\r\nControls:\r", flush=True)
+        print("  W/S or ↑/↓  : Navigate statues\r", flush=True)
+        print("  SPACE       : Toggle TX connection\r", flush=True)
+        print("  E           : Toggle exclusive mode\r", flush=True)
+        print("  A           : All TX off\r", flush=True)
+        print("  M           : Show/hide matrix\r", flush=True)
+        print("  Q           : Quit\r", flush=True)
+
+        # Status line
+        enabled_count = len(self.controller.get_enabled_statues())
+        print(f"\r\nActive TX: {enabled_count}/5\r", flush=True)
+
+    def handle_key(self, key: str):
+        """Process keyboard input.
+
+        Args:
+            key: Single character from keyboard
+        """
+        if key == 'q' or key == 'Q' or key == '\x1b':  # ESC
+            self.running = False
+
+        elif key == 'w' or key == 'W' or key == '\x1b[A':  # Up arrow
+            # Move up
+            statues = list(Statue)
+            idx = statues.index(self.selected_statue)
+            if idx > 0:
+                self.selected_statue = statues[idx - 1]
+
+        elif key == 's' or key == 'S' or key == '\x1b[B':  # Down arrow
+            # Move down
+            statues = list(Statue)
+            idx = statues.index(self.selected_statue)
+            if idx < len(statues) - 1:
+                self.selected_statue = statues[idx + 1]
+
+        elif key == ' ':  # Space - toggle TX
+            if self.controller.is_tx_enabled(self.selected_statue):
+                self.controller.disable_tx(self.selected_statue)
+            else:
+                self.controller.enable_tx(self.selected_statue)
+
+        elif key == 'e' or key == 'E':  # Toggle exclusive mode
+            self.controller.set_exclusive_mode(not self.controller.exclusive_mode)
+
+        elif key == 'a' or key == 'A':  # All off
+            self.controller.disable_all_tx()
+
+        elif key == 'm' or key == 'M':  # Toggle matrix display
+            self.show_matrix = not self.show_matrix
+
+    def read_key(self) -> Optional[str]:
+        """Read a key with support for arrow keys.
+
+        Returns:
+            Key character or None if no input
+        """
+        if sys.stdin in select.select([sys.stdin], [], [], 0.1)[0]:
+            key = sys.stdin.read(1)
+
+            # Check for escape sequences (arrow keys)
+            if key == '\x1b':
+                if sys.stdin in select.select([sys.stdin], [], [], 0.01)[0]:
+                    key += sys.stdin.read(1)
+                    if key[-1] == '[':
+                        if sys.stdin in select.select([sys.stdin], [], [], 0.01)[0]:
+                            key += sys.stdin.read(1)
+
+            return key
+        return None
+
+    def run(self):
+        """Run the interactive test loop."""
+        self.setup_terminal()
+
+        try:
+            # Hide cursor
+            print("\033[?25l", end='', flush=True)
+
+            while self.running:
+                self.draw_ui()
+
+                # Check for keyboard input
+                key = self.read_key()
+                if key:
+                    self.handle_key(key)
+
+                time.sleep(0.05)  # Small delay to reduce CPU usage
+
+        except KeyboardInterrupt:
+            pass
+        finally:
+            # Show cursor
+            print("\033[?25h", end='', flush=True)
+            self.restore_terminal()
+            self.clear_screen()
+            print("Test complete.\n")
+
+
+def main():
+    """Run the interactive TX test."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Interactive test for ADG2188 TX switching"
+    )
+    parser.add_argument(
+        '--simulate',
+        action='store_true',
+        help='Run in simulation mode without hardware'
+    )
+
+    args = parser.parse_args()
+
+    print("Starting ADG2188 TX switching test...")
+    print("Initializing controller...")
+
+    test = InteractiveTXTest(simulate=args.simulate)
+
+    if not args.simulate and not test.controller.hardware_available:
+        print("\nWARNING: Hardware not detected, running in simulation mode")
+        print("Make sure:")
+        print("- I2C is enabled (raspi-config)")
+        print("- ADG2188 is powered and connected")
+        print("- smbus2 is installed")
+        input("\nPress Enter to continue in simulation mode...")
+
+    test.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/raspberry_pi/contact/test_audio_setup.py
+++ b/raspberry_pi/contact/test_audio_setup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["numpy", "sounddevice", "soundfile", "fastgoertzel"]
+# ///
+
+"""Test the new audio_file=None behavior."""
+
+from audio.devices import Statue, configure_devices
+from contact.audio_setup import initialize_audio_playback
+
+print("Testing initialize_audio_playback with audio_file=None...")
+print("=" * 60)
+
+# Configure real devices
+devices = configure_devices(max_devices=2)
+if not devices:
+    print("No devices found, using mock devices")
+    devices = [
+        {'statue': Statue.EROS, 'device_index': 0, 'sample_rate': 44100},
+        {'statue': Statue.ELEKTRA, 'device_index': 1, 'sample_rate': 44100}
+    ]
+
+# Test with None - should create silent audio
+print("\nTest 1: audio_file=None (should create silent audio)")
+playback, generators = initialize_audio_playback(devices, audio_file=None, duration_seconds=10)
+
+if playback:
+    print("\n✓ Success! Playback object created with silent audio")
+    print(f"  Generators created: {list(generators.keys())}")
+    playback.stop()
+else:
+    print("\n✗ Failed to create playback object")
+
+print("\n" + "=" * 60)
+print("\nTest 2: Non-existent file (should return None)")
+playback2, generators2 = initialize_audio_playback(devices, audio_file="/tmp/nonexistent.wav")
+
+if playback2 is None and generators2 == {}:
+    print("✓ Correctly returned (None, {}) for missing file")
+else:
+    print("✗ Should have returned (None, {}) for missing file")
+    if playback2:
+        playback2.stop()
+        
+print("\nTests complete!")

--- a/raspberry_pi/contact/tx_control.py
+++ b/raspberry_pi/contact/tx_control.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""TX switching control for statue audio routing.
+
+This module provides high-level control for managing transmitter connections
+to prevent signal loading in the Missing Link installation. It wraps the
+ADG2188 switch matrix to provide statue-specific TX enable/disable functionality.
+
+Key features:
+- Maps statue names to switch matrix pins
+- Provides simulation mode for testing without hardware
+- Tracks TX connection states
+- Ensures only one TX can be connected at a time (optional)
+"""
+
+from typing import Optional
+
+from audio.devices import Statue
+
+try:
+    from .adg2188 import ADG2188
+    HAS_ADG2188 = True
+except ImportError:
+    HAS_ADG2188 = False
+    print("ADG2188 module not available - TX control will run in simulation mode")
+
+
+class TXController:
+    """Manage TX connections to prevent signal loading."""
+    
+    # Map statues to Y inputs (TX connections)
+    STATUE_TX_MAP = {
+        Statue.EROS: 0,     # Y0
+        Statue.ELEKTRA: 1,  # Y1
+        Statue.SOPHIA: 2,   # Y2
+        Statue.ULTIMO: 3,   # Y3
+        Statue.ARIEL: 4,    # Y4
+    }
+    
+    BUS_X_PIN = 0  # X0 is common bus output
+    
+    def __init__(self, simulate: bool = False, exclusive_mode: bool = False):
+        """Initialize TX controller.
+        
+        Args:
+            simulate: If True, simulate switch operations without hardware
+            exclusive_mode: If True, only one TX can be enabled at a time
+        """
+        self.simulate = simulate
+        self.exclusive_mode = exclusive_mode
+        self.hardware_available = False
+        
+        if not simulate and HAS_ADG2188:
+            try:
+                self.switch = ADG2188()
+                if self.switch.verify_communication():
+                    self.hardware_available = True
+                    print("ADG2188 hardware initialized successfully")
+                else:
+                    print("ADG2188 communication failed - running in simulation mode")
+                    self.simulate = True
+            except Exception as e:
+                print(f"ADG2188 hardware not available: {e}")
+                print("Running in simulation mode")
+                self.simulate = True
+        else:
+            self.simulate = True
+            
+        # Track TX states
+        self.tx_states = {statue: False for statue in Statue}
+        
+        # Initialize with all TX disconnected
+        if self.hardware_available:
+            self.switch.clear_all()
+        
+    def enable_tx(self, statue: Statue) -> bool:
+        """Connect statue TX to bus.
+        
+        Args:
+            statue: Statue to enable TX for
+            
+        Returns:
+            True if successful
+        """
+        y_pin = self.STATUE_TX_MAP.get(statue)
+        if y_pin is None:
+            print(f"Unknown statue: {statue}")
+            return False
+        
+        # In exclusive mode, disable all other TX first
+        if self.exclusive_mode:
+            for other_statue in Statue:
+                if other_statue != statue and self.tx_states[other_statue]:
+                    self.disable_tx(other_statue)
+        
+        if self.simulate:
+            self.tx_states[statue] = True
+            print(f"[SIM] TX enabled: {statue.value}")
+            return True
+        else:
+            try:
+                success = self.switch.connect(y_pin, self.BUS_X_PIN)
+                if success:
+                    self.tx_states[statue] = True
+                    print(f"TX enabled: {statue.value}")
+                return success
+            except Exception as e:
+                print(f"Failed to enable TX for {statue.value}: {e}")
+                return False
+    
+    def disable_tx(self, statue: Statue) -> bool:
+        """Disconnect statue TX from bus.
+        
+        Args:
+            statue: Statue to disable TX for
+            
+        Returns:
+            True if successful
+        """
+        y_pin = self.STATUE_TX_MAP.get(statue)
+        if y_pin is None:
+            print(f"Unknown statue: {statue}")
+            return False
+            
+        if self.simulate:
+            self.tx_states[statue] = False
+            print(f"[SIM] TX disabled: {statue.value}")
+            return True
+        else:
+            try:
+                success = self.switch.disconnect(y_pin, self.BUS_X_PIN)
+                if success:
+                    self.tx_states[statue] = False
+                    print(f"TX disabled: {statue.value}")
+                return success
+            except Exception as e:
+                print(f"Failed to disable TX for {statue.value}: {e}")
+                return False
+    
+    def is_tx_enabled(self, statue: Statue) -> bool:
+        """Check if statue TX is connected.
+        
+        Args:
+            statue: Statue to check
+            
+        Returns:
+            True if TX is enabled
+        """
+        return self.tx_states.get(statue, False)
+    
+    def disable_all_tx(self):
+        """Disconnect all TX from bus."""
+        for statue in Statue:
+            if self.tx_states[statue]:
+                self.disable_tx(statue)
+    
+    def get_enabled_statues(self) -> list[Statue]:
+        """Get list of statues with TX enabled.
+        
+        Returns:
+            List of statues with TX currently enabled
+        """
+        return [statue for statue, enabled in self.tx_states.items() if enabled]
+    
+    def print_status(self):
+        """Print current TX connection status."""
+        print("TX Connection Status:")
+        print("-" * 30)
+        for statue in Statue:
+            status = "ON " if self.tx_states[statue] else "OFF"
+            print(f"{statue.value:8s} TX: [{status}]")
+        
+        if self.simulate:
+            print("\n[SIMULATION MODE]")
+        elif self.hardware_available:
+            print("\n[HARDWARE MODE]")
+    
+    def set_exclusive_mode(self, exclusive: bool):
+        """Set whether only one TX can be enabled at a time.
+        
+        Args:
+            exclusive: If True, enabling a TX disables all others
+        """
+        self.exclusive_mode = exclusive
+        if exclusive and len(self.get_enabled_statues()) > 1:
+            print("Multiple TX enabled - disabling all but first")
+            enabled = self.get_enabled_statues()
+            for statue in enabled[1:]:
+                self.disable_tx(statue)
+
+
+def main():
+    """Test TX controller functionality."""
+    import time
+    
+    print("TX Controller Test")
+    print("=" * 40)
+    
+    # Test in simulation mode first
+    print("\n1. Testing in simulation mode:")
+    controller = TXController(simulate=True)
+    
+    # Enable some TX
+    controller.enable_tx(Statue.EROS)
+    controller.enable_tx(Statue.ELEKTRA)
+    controller.print_status()
+    
+    # Test exclusive mode
+    print("\n2. Testing exclusive mode:")
+    controller.set_exclusive_mode(True)
+    controller.enable_tx(Statue.SOPHIA)  # Should disable others
+    controller.print_status()
+    
+    # Test disable all
+    print("\n3. Testing disable all:")
+    controller.disable_all_tx()
+    controller.print_status()
+    
+    # Try hardware mode
+    print("\n4. Attempting hardware mode:")
+    hw_controller = TXController(simulate=False)
+    if hw_controller.hardware_available:
+        print("Hardware detected - running quick test")
+        hw_controller.enable_tx(Statue.EROS)
+        time.sleep(1)
+        hw_controller.disable_tx(Statue.EROS)
+    else:
+        print("No hardware available")
+
+
+if __name__ == "__main__":
+    main()

--- a/raspberry_pi/controller/controller.py
+++ b/raspberry_pi/controller/controller.py
@@ -339,8 +339,8 @@ def load_audio_devices():
     """Query audio devices and map them to statues using devices.py."""
     global audio_devices
 
-    # Use the devices.py configuration which handles HiFiBerry
-    audio_devices = configure_devices(debug=debug)  # max_devices=X for testing
+    # Use the devices.py configuration which handles HiFiBerry and channel mapping
+    audio_devices = configure_devices(debug=debug)  # max_devices=X for testing, channel_mode auto-detected from env
     audio_devices.sort(key=lambda d: d["channel_index"])
     if debug:
         print(f"Audio devices: {json.dumps(audio_devices, indent=2)}")
@@ -755,12 +755,16 @@ class ControllerDebugHandler(BaseHTTPRequestHandler):
                 }
             )
         elif self.path == "/config/static":
+            # Include channel mode info if available
+            import os
+            channel_mode = os.environ.get("AUDIO_CHANNEL_MODE", "ORIGINAL")
             self._send_response(
                 {
                     "board_config": board_config,
                     "teensy_config": teensy_config,
                     "segment_map": segment_map,
                     "audio_devices": audio_devices,
+                    "audio_channel_mode": channel_mode,
                 }
             )
         elif self.path == "/config/dynamic":

--- a/raspberry_pi/debug_audio.py
+++ b/raspberry_pi/debug_audio.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["sounddevice"]
+# ///
+
+"""Debug script to check audio device detection."""
+
+import re
+import sounddevice as sd
+
+print("Available audio devices:")
+devices = sd.query_devices()
+print(f"Total devices: {len(devices)}\n")
+
+# Pattern for parsing device names
+pattern = r'^([^:]*): ([^(]*) \((hw:\d+,\d+)\)$'
+
+usb_devices = []
+for i, d in enumerate(devices):
+    print(f"  {i}: {d['name']}")
+    print(f"     Inputs: {d['max_input_channels']}, Outputs: {d['max_output_channels']}")
+    print(f"     Sample rate: {d['default_samplerate']} Hz")
+    
+    # Check if it's a USB device
+    match = re.search(pattern, d['name'])
+    if match and 'usb' in d['name'].lower():
+        hw_id = match.group(3)
+        usb_devices.append({
+            'index': i,
+            'name': d['name'],
+            'hw_id': hw_id,
+            'outputs': d['max_output_channels']
+        })
+        print(f"     -> USB device detected: {hw_id}")
+    print()
+
+print(f"\nFound {len(usb_devices)} USB audio devices:")
+for dev in usb_devices:
+    print(f"  Device {dev['index']}: {dev['hw_id']} - {dev['name']}")
+
+print("\nExpected mappings:")
+expected = {
+    "hw:2,0": "EROS",
+    "hw:3,0": "ELEKTRA", 
+    "hw:4,0": "ARIEL",
+    "hw:5,0": "SOPHIA",
+    "hw:6,0": "ULTIMO"
+}
+
+for hw_id, statue in expected.items():
+    found = any(d['hw_id'] == hw_id for d in usb_devices)
+    status = "✓" if found else "✗"
+    print(f"  {status} {statue}: {hw_id}")

--- a/teensy/FirstContact_controller/StatueConfig.cpp
+++ b/teensy/FirstContact_controller/StatueConfig.cpp
@@ -1,0 +1,36 @@
+/*
+StatueConfig.cpp - Runtime configuration variables for multi-statue system
+*/
+
+#include "StatueConfig.h"
+#include <string.h>
+
+// Runtime configuration variables (initialized from compile-time defaults)
+int statueFrequencies[MAX_STATUES];
+char statueNames[MAX_STATUES][10];
+int myStatueIndex = MY_STATUE_INDEX;
+int numStatues = NUM_STATUES;
+bool configReceived = false;
+
+// Initialize runtime configuration from compile-time defaults
+void initDefaultConfig() {
+  // Copy default frequencies and names to runtime arrays
+  for (int i = 0; i < MAX_STATUES; i++) {
+    statueFrequencies[i] = STATUE_FREQUENCIES[i];
+    strcpy(statueNames[i], STATUE_NAMES[i]);
+  }
+  
+  // Set initial values from defines
+  myStatueIndex = MY_STATUE_INDEX;
+  numStatues = NUM_STATUES;
+  configReceived = false;
+  
+  Serial.println("Initialized with default configuration:");
+  Serial.print("  My statue: ");
+  Serial.print(statueNames[myStatueIndex]);
+  Serial.print(" (");
+  Serial.print(statueFrequencies[myStatueIndex]);
+  Serial.println(" Hz)");
+  Serial.print("  Active statues: ");
+  Serial.println(numStatues);
+}


### PR DESCRIPTION
Implement configurable channel mapping to support hardware with fewer working channels. The spare DAC8x board only has channels 0,1,4,5 working.

This is draft contingency code in case we need to fall back to the half-broken 4-remaining-channel audio hat.

Note that most of the code was generated with Claude Code with minimal oversight, so changes are likely needed and more thorough review. The goal here is to have some code to start with for work offline on the playa.

Key features:
- Three mapping modes: ORIGINAL (1:1), SPARE_DAC8X (shared channels), SINGLE_SPEAKER
- Audio mixing with gain adjustment (0.7) when channels are shared
- Eros and Elektra share channel 0 in SPARE_DAC8X mode
- Environment variable configuration: AUDIO_CHANNEL_MODE
- Test utility with tone generation for verifying mappings

Changes:
- Add audio_config.py with channel mapping presets
- Update devices.py to use configurable channel mappings
- Enhance music.py with audio mixing for shared channels
- Add channel mode info to controller debug endpoints
- Create test_channel_mapping.py for testing configurations
- Add Makefile targets for easy testing

Also includes unrelated ADG2188 switch control and debug utilities.